### PR TITLE
fix: update league of legends support

### DIFF
--- a/src/content/docs/en/usage/gaming.mdx
+++ b/src/content/docs/en/usage/gaming.mdx
@@ -55,7 +55,7 @@ Lutris is a game launcher for Linux. It supports installing and managing your ga
 
 ### League of Legends
 
-League of Legends is a popular MOBA game developed by Riot Games. It is available on Windows, macOS, and Android. It is not officially supported on Linux, but it can be run using a special build of Wine by GloriousEggroll.
+League of Legends is a popular MOBA game developed by Riot Games. It is available on Windows and macOS. It will not run on Linux, as it uses a kernel-level anti-cheat software that is not compatible with Wine/Proton.
 
 ### EA Desktop
 


### PR DESCRIPTION
Update the League of Legends section on the gaming usage page, as it introduced Vanguard AC (the same anti-cheat as VALORANT) recently.