### PR TITLE
Add UEFI ROM Chromebook and fix up Thinkpad in bios keys page

### DIFF
--- a/src/content/docs/en/setup/bioskeys.mdx
+++ b/src/content/docs/en/setup/bioskeys.mdx
@@ -5,37 +5,40 @@ description: "How to enter the BIOS or Boot Menu on various Computers"
 
 These are the keys (or combination of keys) used to enter the boot menu or UEFI/BIOS settings on different computers.
 
-| Manufacturer      | UEFI/BIOS             | Boot Menu                | Notes                                                                                      |
-| ----------------- | --------------------- | ------------------------ | ------------------------------------------------------------------------------------------ |
-| Acer              | F2 or Del             | Esc, F9, F12             |                                                                                            |
-| Aorus             | Del, F2               | F12                      |                                                                                            |
-| ASRock            | Del, F2               | F11                      |                                                                                            |
-| ASUS              | F2 or Del             | Esc, F8                  |                                                                                            |
-| Compaq            | F10                   | F9                       |                                                                                            |
-| Dell              | F2                    | F12                      |                                                                                            |
-| Dell (Alienware)  | F2                    | F12                      |                                                                                            |
-| Dell (Tablets)    | Volume Down+Power     | Volume Up+Power          |                                                                                            |
-| ECS               | Del                   | F7                       |                                                                                            |
-| EVGA              | Del                   | F7                       |                                                                                            |
-| Gateway           | Del, F1, F2           | F12                      |                                                                                            |
-| Gigabyte          | Del, F2               | F12                      |                                                                                            |
-| HP                | ESC, F10              | Esc, F9                  |                                                                                            |
-| Intel             | F2                    | F10                      |                                                                                            |
-| ThinkPads         | -                     | F12, Enter, ThinkVantage | You can access the BIOS or UEFI menu from the boot menu                                    |
-| Lenovo (Desktops) | F1                    | F12                      |                                                                                            |
-| Lenovo (Laptops)  | F1+Enter, Novo Button | F12, Novo Button         |                                                                                            |
-| MSI               | Del                   | F11                      |                                                                                            |
-| Microsoft         | Volume Up+Power       | -                        | There is a boot menu available in the UEFI Settings                                        |
-| Origin PC         | F2                    | F2                       |                                                                                            |
-| Razer             | Del, F1               | Esc, F12                 |                                                                                            |
-| Samsung           | F2                    | F10                      |                                                                                            |
-| Supermicro        | Del, F4, F11          | F11                      |                                                                                            |
-| System76          | F2                    | F7                       |                                                                                            |
-| Toshiba           | F2                    | F12                      |                                                                                            |
-| TUXEDO            | Esc, F2               | F7                       |                                                                                            |
-| Intel Macs        | -                     | Hold Option (⌥) or Alt   | You can change NVRAM variables inside the OS. If you know what you're doing, power to you. |
-| Zotac             | Del                   | F8                       |                                                                                            |
+| Manufacturer           | UEFI/BIOS                 | Boot Menu                  | Notes                                                                                                                                                             |
+| ---------------------- | ------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Acer                   | F2 or Del                 | Esc, F9, F12               |                                                                                                                                                                   |
+| Aorus                  | Del, F2                   | F12                        |                                                                                                                                                                   |
+| ASRock                 | Del, F2                   | F11                        |                                                                                                                                                                   |
+| ASUS                   | F2 or Del                 | Esc, F8                    |                                                                                                                                                                   |
+| Chromebooks (UEFI ROM) | esc                       | -                          | Requires [mrchromebox UEFI Full ROM] firmware (coreboot) to be flashed. Boot menu can be accessed from the UEFI menu.                                             |
+| Compaq                 | F10                       | F9                         |                                                                                                                                                                   |
+| Dell                   | F2                        | F12                        |                                                                                                                                                                   |
+| Dell (Alienware)       | F2                        | F12                        |                                                                                                                                                                   |
+| Dell (Tablets)         | Volume Down+Power         | Volume Up+Power            |                                                                                                                                                                   |
+| ECS                    | Del                       | F7                         |                                                                                                                                                                   |
+| EVGA                   | Del                       | F7                         |                                                                                                                                                                   |
+| Gateway                | Del, F1, F2               | F12                        |                                                                                                                                                                   |
+| Gigabyte               | Del, F2                   | F12                        |                                                                                                                                                                   |
+| HP                     | ESC, F10                  | Esc, F9                    |                                                                                                                                                                   |
+| Intel                  | F2                        | F10                        |                                                                                                                                                                   |
+| Lenovo (Desktops)      | F1                        | F12                        |                                                                                                                                                                   |
+| Lenovo (Laptops)       | F1+Enter, Novo Button     | F12, Novo Button           |                                                                                                                                                                   |
+| Lenovo (ThinkPad)      | F1, Startup Interupt Menu | F12, Startup Interupt Menu | You can (and may need to) access the BIOS/UEFI and boot menus from the Startup Interput Menu, which is accessed by pressing Enter (or ThinkVantage when present). |
+| MSI                    | Del                       | F11                        |                                                                                                                                                                   |
+| Microsoft              | Volume Up+Power           | -                          | There is a boot menu available in the UEFI Settings                                                                                                               |
+| Origin PC              | F2                        | F2                         |                                                                                                                                                                   |
+| Razer                  | Del, F1                   | Esc, F12                   |                                                                                                                                                                   |
+| Samsung                | F2                        | F10                        |                                                                                                                                                                   |
+| Supermicro             | Del, F4, F11              | F11                        |                                                                                                                                                                   |
+| System76               | F2                        | F7                         |                                                                                                                                                                   |
+| Toshiba                | F2                        | F12                        |                                                                                                                                                                   |
+| TUXEDO                 | Esc, F2                   | F7                         |                                                                                                                                                                   |
+| Intel Macs             | -                         | Hold Option (⌥) or Alt     | You can change NVRAM variables inside the OS. If you know what you're doing, power to you.                                                                        |
+| Zotac                  | Del                       | F8                         |                                                                                                                                                                   |
 
 #### [Next Up: Installation →](/en/setup/installation)
 
 #### [← Back To: Getting Ultramarine](/en/setup/getting)
+
+[mrchromebox UEFI Full ROM]: https://docs.chrultrabook.com/docs/firmware/about.html#rw-legacy


### PR DESCRIPTION
IBM Thinkpads are not 64-bit, which is why I added Lenovo to the Thinkpad name.