### PR TITLE
add NVIDIA Tegra to the Anywhere wishlist

### DIFF
--- a/src/content/docs/en/anywhere/anywhere.mdx
+++ b/src/content/docs/en/anywhere/anywhere.mdx
@@ -46,6 +46,10 @@ Devices in the **Wishlist** category are platforms we would like to support one 
 - [Smart TV Devices](/en/anywhere/ott)
 - [Thin Clients](/en/anywhere/thin)
 - [Steam Deck](/en/anywhere/steamdeck)
+- [NVIDIA Tegra-based devices](/en/anywhere/tegra)
+  - Nintendo Switch
+  - NVIDIA Shield
+  - NVIDIA Jetson microcomputers
 
 #### [Next Up: Microsoft Surface →](/en/anywhere/surface)
 

--- a/src/content/docs/en/anywhere/anywhere.mdx
+++ b/src/content/docs/en/anywhere/anywhere.mdx
@@ -46,10 +46,9 @@ Devices in the **Wishlist** category are platforms we would like to support one 
 - [Smart TV Devices](/en/anywhere/ott)
 - [Thin Clients](/en/anywhere/thin)
 - [Steam Deck](/en/anywhere/steamdeck)
-- [NVIDIA Tegra-based devices](/en/anywhere/tegra)
-  - Nintendo Switch
-  - NVIDIA Shield
-  - NVIDIA Jetson microcomputers
+- [Nintendo Switch](/en/anywhere/tegra)
+- [NVIDIA Shield](/en/anywhere/tegra)
+- [NVIDIA Jetson microcomputers](/en/anywhere/tegra)
 
 #### [Next Up: Microsoft Surface →](/en/anywhere/surface)
 

--- a/src/content/docs/en/anywhere/tegra.mdx
+++ b/src/content/docs/en/anywhere/tegra.mdx
@@ -11,7 +11,7 @@ import Alert from "../../../../components/Docs/Alert.astro";
 </Alert>
 
 While our team has some experience with NVIDIA Tegra devices, especially the Nintendo Switch.
-We have not yet started work on supporting these devices in Ultramarine, and they are still in the **Wishlist Phase**.
+There is interest in running Ultramarine on these devices, but we haven’t started work on a port yet.
 
 In the meanwhile, we are tracking the progress of the [Switchroot](https://switchroot.org/) project, which aims to bring Linux to the Nintendo Switch and
 other Tegra-based SoCs, such as the Jetson/Xavier/Orin series, the NVIDIA Shield and more.

--- a/src/content/docs/en/anywhere/tegra.mdx
+++ b/src/content/docs/en/anywhere/tegra.mdx
@@ -10,7 +10,7 @@ import Alert from "../../../../components/Docs/Alert.astro";
   page is subject to change.
 </Alert>
 
-While our team has some experience with NVIDIA Tegra devices, especially the Nintendo Switch.
+Most of the team has a modern Tegra device, most commonly, the Nintendo Switch.
 There is interest in running Ultramarine on these devices, but we haven’t started work on a port yet.
 
 In the meanwhile, we are tracking the progress of the [Switchroot](https://switchroot.org/) project, which aims to bring Linux to the Nintendo Switch and

--- a/src/content/docs/en/anywhere/tegra.mdx
+++ b/src/content/docs/en/anywhere/tegra.mdx
@@ -22,26 +22,26 @@ We'll be mostly documenting the process for the Switch, but the same principles 
 
 ## Nintendo Switch
 
-The Switch loads from a 32GB (or 64GB if you have an OLED version) eMMC storage, which is a detachable module.
+The Switch loads from a 32GB (or 64GB on the OLED model) eMMC, which is a detachable module.
 
 Older revisions of the Switch with the X1 SoC (the original 2017 launch model, AKA the "White Box" or "Erista" SoC)
-are the most compatible with Linux, since the hardware support for the X1 itself has been mainlined in the Linux kernel
-and are vulnerable to [CVE-2018-6242 (Fusée Gelée)](https://nvd.nist.gov/vuln/detail/cve-2018-6242) which allows for arbitrary code execution in the boot ROM.
+are the most compatible with Linux, since the hardware support for the X1 itself has been mainlined in the Linux kernel.
+This model is vulnerable to [CVE-2018-6242 (Fusée Gelée)](https://nvd.nist.gov/vuln/detail/cve-2018-6242) which allows for arbitrary code execution in the boot ROM.
 
-Newer revisions of the Switch with the X1+ SoC (the 2019 revision, AKA the "Red Box" or "Mariko" SoC) and later models
-(i.e the Switch Lite and OLED models, also codenamed "Aula"), are not vulnerable to Fusée Gelée, and require a different exploit which is a combination
-of eMMC interception and a reset glitch to load into a custom bootloader. This requires hardware modifications and is not as straightforward as the original exploit.
+Newer revisions of the Switch with the X1+ SoC (the 2019 revision, AKA "Red Box" or "Mariko" SoC) and later models
+like the Lite and OLED models (also codenamed "Aula") are not vulnerable to Fusée Gelée, and require a different exploit which is a combination
+of eMMC interception and a reset glitch to load a custom bootloader. This requires hardware modifications and is not as straightforward as the original exploit.
 
 "Mariko" SoCs are also not yet supported by the mainline Linux kernel, and require a custom kernel to boot.
 
 The most common bootloader payload used to run arbitrary code on the Switch is [hekate](https://github.com/ctcaer/hekate),
-which is a custom bootloader that provides a graphical boot menu and a partition manager. It can also be used to dump the eMMC storage data and
-create what's called an "emuMMC" which is a virtualized eMMC partition that can be used to run a backup image of [Horizon OS]
-without modifying the actual eMMC data.
+a custom bootloader that provides a graphical boot menu and partition manager. It can also be used to dump the eMMC storage data and
+create an "emuMMC” (a virtualized eMMC partition that can be used to run a backup image of HorizonOS, the stock firmware
+without modifying the actual eMMC data.)
 
 ## Implementation
 
-The Switchroot boot process creates a boot menu entry in hekate that loads [U-Boot], which in turn reads a custom boot script that does the following:
+The Switchroot boot process creates a boot menu entry in Hekate that loads [U-Boot], which in turn reads a custom boot script that does the following:
 
 1. (If the user is on a Switch Lite) loads the calibration data for the embedded analog sticks
 2. Loads the device tree blobs (DTB) for the Switch from the SD card

--- a/src/content/docs/en/anywhere/tegra.mdx
+++ b/src/content/docs/en/anywhere/tegra.mdx
@@ -1,0 +1,17 @@
+---
+title: "NVIDIA Tegra (Anywhere)"
+description: "NVIDIA Tegra devices in the Ultramarine Anywhere Initiative"
+---
+
+import Alert from "../../../../components/Docs/Alert.astro";
+
+<Alert type="info">
+  This device type is still in the **Wishlist Phase**. All information on this
+  page is subject to change.
+</Alert>
+
+While our team has some experience with NVIDIA Tegra devices, especially the Nintendo Switch.
+We have not yet started work on supporting these devices in Ultramarine, and they are still in the **Wishlist Phase**.
+
+In the meanwhile, we are tracking the progress of the [Switchroot](https://switchroot.org/) project, which aims to bring Linux to the Nintendo Switch and
+other Tegra-based SoCs, such as the Jetson/Xavier/Orin series, the NVIDIA Shield and more.

--- a/src/content/docs/en/anywhere/tegra.mdx
+++ b/src/content/docs/en/anywhere/tegra.mdx
@@ -16,7 +16,7 @@ There is interest in running Ultramarine on these devices, but we haven’t star
 In the meanwhile, we are tracking the progress of the [Switchroot](https://switchroot.org/) project, which aims to bring Linux to the Nintendo Switch and
 other Tegra-based SoCs, such as the Jetson/Xavier/Orin series, the NVIDIA Shield and more.
 
-The boot process for Tegra devices is similar to other ARM-based Android devices, with slight differences especially
+The boot process for Tegra devices is similar to other ARM-based Android devices, but with slight differences, especially
 for the Nintendo Switch since it uses a completely custom firmware, due to Nintendo's security measures.
 We'll be mostly documenting the process for the Switch, but the same principles apply to other Tegra devices.
 

--- a/src/content/docs/en/anywhere/tegra.mdx
+++ b/src/content/docs/en/anywhere/tegra.mdx
@@ -15,3 +15,53 @@ There is interest in running Ultramarine on these devices, but we haven’t star
 
 In the meanwhile, we are tracking the progress of the [Switchroot](https://switchroot.org/) project, which aims to bring Linux to the Nintendo Switch and
 other Tegra-based SoCs, such as the Jetson/Xavier/Orin series, the NVIDIA Shield and more.
+
+The boot process for Tegra devices is similar to other ARM-based Android devices, with slight differences especially
+for the Nintendo Switch since it uses a completely custom firmware, due to Nintendo's security measures.
+We'll be mostly documenting the process for the Switch, but the same principles apply to other Tegra devices.
+
+## Nintendo Switch
+
+The Switch loads from a 32GB (or 64GB if you have an OLED version) eMMC storage, which is a detachable module.
+
+Older revisions of the Switch with the X1 SoC (the original 2017 launch model, AKA the "White Box" or "Erista" SoC)
+are the most compatible with Linux, since the hardware support for the X1 itself has been mainlined in the Linux kernel
+and are vulnerable to [CVE-2018-6242 (Fusée Gelée)](https://nvd.nist.gov/vuln/detail/cve-2018-6242) which allows for arbitrary code execution in the boot ROM.
+
+Newer revisions of the Switch with the X1+ SoC (the 2019 revision, AKA the "Red Box" or "Mariko" SoC) and later models
+(i.e the Switch Lite and OLED models, also codenamed "Aula"), are not vulnerable to Fusée Gelée, and require a different exploit which is a combination
+of eMMC interception and a reset glitch to load into a custom bootloader. This requires hardware modifications and is not as straightforward as the original exploit.
+
+"Mariko" SoCs are also not yet supported by the mainline Linux kernel, and require a custom kernel to boot.
+
+The most common bootloader payload used to run arbitrary code on the Switch is [hekate](https://github.com/ctcaer/hekate),
+which is a custom bootloader that provides a graphical boot menu and a partition manager. It can also be used to dump the eMMC storage data and
+create what's called an "emuMMC" which is a virtualized eMMC partition that can be used to run a backup image of [Horizon OS]
+without modifying the actual eMMC data.
+
+## Implementation
+
+The Switchroot boot process creates a boot menu entry in hekate that loads [U-Boot], which in turn reads a custom boot script that does the following:
+
+1. (If the user is on a Switch Lite) loads the calibration data for the embedded analog sticks
+2. Loads the device tree blobs (DTB) for the Switch from the SD card
+3. Sets up Linux kernel command line arguments (if configured to do so)
+    - Disables the touch screen tuning parameters (optional)
+    - Disables HDMI CEC auto-negotiation (optional)
+    - Disables WiFi VHT80 bonding (if running the mainline kernel)
+    - Force-enables NVENC/NVDEC support and sets the memory address for the framebuffer
+
+4. Finally, loads the Linux kernel and the initramfs from the SD card
+
+If the boot process fails at any point, the script waits for 10 seconds and then reboots the device.
+
+## Ultramarine Notes
+
+To properly support BLS ([Boot Loader Specification]) on the Switch, we want to slightly modify the U-Boot script to instead
+chainload another bootloader (such as GRUB, systemd-boot or [Submarine]) which can then read the BLS configurations and present
+the user with the boot menu options.
+
+[Horizon OS]: https://en.wikipedia.org/wiki/Nintendo_Switch_system_software
+[U-Boot]: https://en.wikipedia.org/wiki/Das_U-Boot
+[Submarine]: https://github.com/FyraLabs/submarine
+[Boot Loader Specification]: https://uapi-group.org/specifications/specs/boot_loader_specification/


### PR DESCRIPTION
This PR adds NVIDIA Tegra SoCs to the Ultramarine Anywhere initiative wishlist. This includes the Nintendo Switch, NVIDIA Shield, and NVIDIA Jetson microcomputers.

I also put some specific device examples in the wishlist section in a nested list, but the CSS seems to be broken for that. That might need to be worked on later.
