### PR TITLE
Fix link 'Set up Secure Boot'

### DIFF
--- a/src/content/docs/en/setup/postinstall.mdx
+++ b/src/content/docs/en/setup/postinstall.mdx
@@ -125,7 +125,7 @@ sudo dnf reinstall -y kernel-core
 ```
 
 6. Reboot your system and make sure it boots correctly, run `sudo bootctl` to check if the boot process is correct.
-7. (Optional) Proceed to [Set up Secure Boot](#set-up-secure-boot) if you want to re-enable Secure Boot.
+7. (Optional) Proceed to [Set up Secure Boot](#secure-boot-with-systemd-boot) if you want to re-enable Secure Boot.
 
 ### Secure Boot with systemd-boot
 


### PR DESCRIPTION
the link to the title was broken; maybe the heading had been changed?