### PR TITLE
Fix broken links and make the links uniform

### DIFF
--- a/src/content/docs/en/anywhere/wsl.mdx
+++ b/src/content/docs/en/anywhere/wsl.mdx
@@ -143,7 +143,7 @@ This will install everything you need for hardware acceleration through Ultramar
 
 ### Version Upgrading
 
-To version upgrade Ultramarine WSL, check the instructions [here](https://wiki.ultramarine-linux.org/en/release/42-upgrades#upgrading-ultramarine-wsl-system-versions).
+To version upgrade Ultramarine WSL, check the instructions [here](/en/release/42-upgrades#upgrading-ultramarine-wsl-system-versions).
 
 ## More Information
 

--- a/src/content/docs/en/linux/overview.mdx
+++ b/src/content/docs/en/linux/overview.mdx
@@ -17,7 +17,7 @@ People use Linux on the desktop for all sorts of reasons. For our purposes, we'l
 
 ### Customization
 
-Linux is incredibly customizable. You can change anything from the way your desktop icons look to the way apps load and the behavior of the device itself. Ultramarine provides easy ways to do this, like theme support, power management profiles (in most editions) and in [umcli](https://wiki.ultramarine-linux.org/en/usage/umcli/).
+Linux is incredibly customizable. You can change anything from the way your desktop icons look to the way apps load and the behavior of the device itself. Ultramarine provides easy ways to do this, like theme support, power management profiles (in most editions) and in [umcli](/en/usage/umcli/).
 
 ### Freedom
 
@@ -59,4 +59,4 @@ Ultramarine is built on Fedora, the base for Red Hat's Enterprise Linux. This me
 
 #### [Next Up: The Filesystem →](/en/linux/filesystem)
 
-#### [← Back To: eduroam](https://wiki.ultramarine-linux.org/en/usage/eduroam/)
+#### [← Back To: eduroam](/en/usage/eduroam/)

--- a/src/content/docs/en/setup/getting.mdx
+++ b/src/content/docs/en/setup/getting.mdx
@@ -77,7 +77,7 @@ CertUtil -hashfile PATH\TO\ULTRAMARINE.ISO SHA256
 
 <Alert type="info">
   If you're using a Raspberry Pi, stop here and go to the [Raspberry Pi
-  instructions](/en/installation/rpi)
+  instructions](/en/anywhere/rpi)
 </Alert>
 
 ## Creating the Installer

--- a/src/content/docs/en/usage/eduroam.mdx
+++ b/src/content/docs/en/usage/eduroam.mdx
@@ -31,7 +31,7 @@ Final step! Enter your credentials (usually your institution-issued email addres
 You're done! Just visit any eduroam hotspot and you'll be automatically connected.
 ![Running CAT](/assets/eduroam/done.png)
 
-If you need further support, we recommend contacting your institution's helpdesk, or hopping into one of [our chats](https://wiki.ultramarine-linux.org/en/community/community/).
+If you need further support, we recommend contacting your institution's helpdesk, or hopping into one of [our chats](/en/community/community/).
 
 #### [Next Up: Linux Concepts: What is Linux? →](/en/linux/overview)
 

--- a/src/content/docs/en/welcome.mdx
+++ b/src/content/docs/en/welcome.mdx
@@ -13,7 +13,7 @@ If you want to get started with contributing, head to the [Contributing Section]
 
 On this page, you can read about the project, so if you want to become familiar with important concepts and our philosophy, read this first!
 
-If you want to install Ultramarine Linux, head to the [Getting Ultramarine](/en/installation/getting) section.
+If you want to install Ultramarine Linux, head to the [Getting Ultramarine](/en/setup/getting) section.
 
 ## General Philosophy
 


### PR DESCRIPTION
Fix broken links that i encountered. And make the links uniform, from (https://wiki.ultramarine-linux.org/...) into (/...)