### PR TITLE
Add readymade preview images note for Ultramarine 43 in diff-fedora

### DIFF
--- a/src/content/docs/en/release/diff-fedora.mdx
+++ b/src/content/docs/en/release/diff-fedora.mdx
@@ -19,6 +19,7 @@ Changes listed below are non-exhaustive and cumulative, meaning each section con
 
 - `umcli` tweak: cachyos-kernel
 - More fixes to Taidan, including language selection, keyboard variant, etc.
+- 🔥 Readymade preview images
 
 ## Ultramarine 42
 


### PR DESCRIPTION
Added a note about readymade preview images for Ultramarine 43.