### PR TITLE
welcome: Update DNF Counting URL

### DIFF
--- a/src/content/docs/en/welcome.mdx
+++ b/src/content/docs/en/welcome.mdx
@@ -78,7 +78,7 @@ We do not intend to include revivals of Cutefish as they tend to be very short-l
 
 ### Does Ultramarine track or collect my data?
 
-As of now, the only data we collect is a count of how many times a package has been downloaded from Terra or the Ultramarine repository using [DNF Counting](https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/dnf-counting/). This information is not tied to you or your computer.
+As of now, the only data we collect is a count of how many times a package has been downloaded from Terra or the Ultramarine repository using [DNF Counting](https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/dnf-counting/). This information is not tied to you or your computer.
 
 Fyra Labs (the company behind Ultramarine) does not collect any data that can be tied to an individual without express consent from the user.
 


### PR DESCRIPTION
Old URL (https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/dnf-counting/) went to a 404 page